### PR TITLE
Cap the bitrate of sync'd voice channels.

### DIFF
--- a/ags_experiments/cogs/admin.py
+++ b/ags_experiments/cogs/admin.py
@@ -410,7 +410,11 @@ class Admin(commands.Cog):
 
                 elif to_return['type'] == "Voice":
                     # do voice
-                    to_return['bitrate'] = channel.bitrate
+                    if channel.bitrate > 96000:
+                        # Higher bitrates require nitro boosts, which the destination server may not have. Assume not.
+                        to_return['bitrate'] = 96000
+                    else:
+                        to_return['bitrate'] = channel.bitrate
                     to_return['user_limit'] = channel.user_limit
             return to_return
 


### PR DESCRIPTION
As the destination server may not have boosts.

Turns out discord API just throws an error if you try to create high bitrate voice channels through the API on a server that doesn't have sufficient boosts. Who knew?!